### PR TITLE
Removing empty 200 header from oauth ask_for_access_token

### DIFF
--- a/lib/class.instagram.oauth.coffee
+++ b/lib/class.instagram.oauth.coffee
@@ -30,8 +30,6 @@ class InstagramOAuth
       @parent._request token_params
       if params['redirect']?
         params['response'].redirect(params['redirect']);
-      else
-        params['response'].writeHead 200, { 'Content-Length': 0, 'Content-Type': 'text/plain' }
       params['response'].end()
 
 module.exports = InstagramOAuth

--- a/lib/class.instagram.oauth.js
+++ b/lib/class.instagram.oauth.js
@@ -33,11 +33,6 @@
         this.parent._request(token_params);
         if (params['redirect'] != null) {
           params['response'].redirect(params['redirect']);
-        } else {
-          params['response'].writeHead(200, {
-            'Content-Length': 0,
-            'Content-Type': 'text/plain'
-          });
         }
         return params['response'].end();
       }


### PR DESCRIPTION
It would be useful if headers were not sent at this point, so we could send them ourselves in the complete callback.

p.s. Thank you for such an awesome library.
